### PR TITLE
feat: docker-compose and readme updates

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,11 @@
+# Use an official PHP Apache runtime
+FROM php:8-apache
+# Enable Apache modules
+RUN a2enmod rewrite
+# Install PostgreSQL client and its PHP extensions
+RUN apt-get update \
+    && apt-get install -y libpq-dev libicu-dev \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install pdo pdo_pgsql intl
+# Set the working directory to /var/www/html
+WORKDIR /var/www/html

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -7,5 +7,6 @@ RUN apt-get update \
     && apt-get install -y libpq-dev libicu-dev \
     && docker-php-ext-configure intl \
     && docker-php-ext-install pdo pdo_pgsql intl
+
 # Set the working directory to /var/www/html
 WORKDIR /var/www/html

--- a/.docker/apache2/idm.conf
+++ b/.docker/apache2/idm.conf
@@ -1,0 +1,26 @@
+<VirtualHost *:80>
+    ServerName identity.local
+    DocumentRoot /var/www/identity/public
+
+    <Directory /var/www/identity>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    <Directory /var/www/identity/public>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+
+        # Redirect all requests to Laravel's front controller
+        RewriteEngine On
+        RewriteBase /
+        RewriteCond %{REQUEST_FILENAME} !-d
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^ index.php [L]
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/.docker/apache2/klms.conf
+++ b/.docker/apache2/klms.conf
@@ -1,0 +1,26 @@
+<VirtualHost *:80>
+    ServerName klms.local
+    DocumentRoot /var/www/klms/public
+
+    <Directory /var/www/klms>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    <Directory /var/www/klms/public>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+
+        # Redirect all requests to Laravel's front controller
+        RewriteEngine On
+        RewriteBase /
+        RewriteCond %{REQUEST_FILENAME} !-d
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^ index.php [L]
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/.env
+++ b/.env
@@ -26,6 +26,10 @@ APP_VERSION=
 # For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #DATABASE_URL=mysql://krru:krru@127.0.0.1:2223/klms
+DATABASE_HOST=127.0.0.1 # localhost required for composer install
+#DATABASE_HOST=database # switch between localhost and database for running composer or docker-compose 
+DATABASE_URL=postgresql://app:app@${DATABASE_HOST}:5432/klms?serverVersion=12&charset=utf8 # app user:pass is the default from docker-compose
+###< doctrine/doctrine-bundle ###
 
 SITE_BASE_SCHEME=https
 SITE_BASE_HOST=klms.at:443

--- a/README.md
+++ b/README.md
@@ -20,12 +20,39 @@ KLMS is tested and running in Production with the following Versions:
 * Yarn 1
 * Composer 2
 
-### Database setup
-Login as the PostgreSQL admin user (usually `postgres`) and create a user
-with an according password and create a database for the KLMS instance.
+### Docker based development setup
+We provide a docker-compose-based setup for running Apache 2, PHP 8 and PostgreSQL 12. 
+Make sure you have cloned KLMS and [IDM](https://github.com/krrug/IDM) in the same folder, located next to each other. 
 
-Running Linux and logged on as root, the following commands perform this actions:
+Run `docker-compose up` to run the webserver, database and mailcatcher.
+
+Follow the [_KLMS setup_](#KLMS%20setup) steps below and come back here.
+
+Then follow the IDM installation steps and return here.
+
+Create a `.env.local` with the updated database string:
+```yml
+DATABASE_HOST=database
+DATABASE_URL=postgresql://app:app@${DATABASE_HOST}:5432/klms?serverVersion=12&charset=utf8
 ```
+Setting the host is required since docker-compose containers are linked to each other and connections happen through their hostnames.
+
+Additionally, you need two local DNS entries. For Linux/MacOS edit the file `/etc/hosts` with root permissions. Windows entries can be found in the `C:\Windows\System32\drivers\etc` folder, also use elevated permissions for editing.
+```
+127.0.0.1 klms.local identity.local
+```
+Further database setup below is not necessary.
+
+Restart docker-compose to apply the updated environment file. 
+
+You should be able to access http://klms.local
+
+### Database setup
+Log in as the PostgreSQL admin user (usually `postgres`), create a user
+with an appropriate password and the database for the KLMS instance.
+
+Running Linux and logging on as root, the following commands perform these actions:
+```bash
 sudo -u postgres -i
 createuser -l -P <db_user>
 createdb -O <db_user> <db_name>
@@ -41,22 +68,23 @@ KLMS_IDM_URL=https://<idm_host>:<idm_port>
 KLMS_IDM_APIKEY=<idm_key>
 ```
 
-To set up the required third party libraries go to the project directory and run
-```
+To set up the required third-party libraries go to the project directory and run
+```bash
 composer install
 yarn install
 yarn encore dev
 ``` 
 
 To create the database schema and some default data run
-```
+```bash
+bin/console doctrine:database:create
 bin/console doctrine:schema:create
 bin/console doctrine:fixtures:load -n
 ```
 
 ### Run KLMS
-Once all setup steps are done start the symfony development server using
-```
+Once all setup steps are done start the Symfony development server using
+```bash
 bin/console server:start
 ```
-Open the printed URL in your browser and login in with a superuser credential 
+Open the printed URL in your browser and log in with a superuser credential 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,35 @@ services:
     volumes:
       - database:/var/lib/postgresql/data:rw
   
+  webserver:
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+    ports:
+      - "80:80"
+    volumes:
+      - ../IDM:/var/www/identity # You need to have the IDM project in the same directory as the KLMS project
+      - .:/var/www/klms
+      - ./.docker/apache2/idm.conf:/etc/apache2/sites-enabled/idm.conf
+      - ./.docker/apache2/klms.conf:/etc/apache2/sites-enabled/klms.conf
+    depends_on:
+      - database
+    links:
+      - database
+
+  # Useful when using postgresql
+  # pgadmin:
+  #   image: dpage/pgadmin4
+  #   environment:
+  #     PGADMIN_DEFAULT_EMAIL: admin@klms.at
+  #     PGADMIN_DEFAULT_PASSWORD: passwd123
+  #   ports:
+  #     - "9080:80"
+  #   depends_on:
+  #     - database
+  #   links:
+  #     - database
+
   mailcatcher:
     image: schickling/mailcatcher
     ports: [ "1025", "1080" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,9 @@ services:
       - database
     links:
       - database
+    extra_hosts:
+      - "klms.local:127.0.0.1"
+      - "identity.local:127.0.0.1"
 
   # Useful when using postgresql
   # pgadmin:


### PR DESCRIPTION
Not sure if this is something you want to have, but I have no local setup of postgres and apache. 
Therefore I added a docker-compose and further installation steps on how to properly install klms + idm.

Wrote it down as far as I remembered the steps from the last days, which should be at least a bit of a guidance - and could be also separated from the docker-compose part. 

One downside of the setup is, that you need to switch DATABASE_HOST for running composer and docker-compose. Not sure what to do about it. 

Leaving it as a draft until we have aligned.