### PR TITLE
feat(seatmap): configurable seat width

### DIFF
--- a/assets/css/modules/seatmap.scss
+++ b/assets/css/modules/seatmap.scss
@@ -44,39 +44,53 @@
   bottom: 0;
   transform: scale(1);
   transform-origin: left top;
-
+  
   .seat {
     position: absolute;
-    height: 27px;
-    width: 27px;
-    border-radius: 30%;
+    border-radius: var(--seatmap-seat-border-radius, 8px);
     cursor: pointer;
 
+    &[data-chair-position="top"], &[data-chair-position="bottom"] {
+      width: calc(var(--seatmap-seat-size, 27px) * var(--seatmap-seat-tableWidthMultiplier, 1));
+      height: var(--seatmap-seat-size, 27px);
+    }
+
+    &[data-chair-position="left"], &[data-chair-position="right"] {
+      width: var(--seatmap-seat-size, 27px);
+      height: calc(var(--seatmap-seat-size, 27px) * var(--seatmap-seat-tableWidthMultiplier, 1));
+    }
+  
     &::before {
       content: '';
       position: absolute;
-      width: 7px;
-      height: 7px;
+      width: var(--seatmap-seat-bullet-size, 6px);
+      height: var(--seatmap-seat-bullet-size, 6px);
+      border-radius: 50%;
+      transform: translate(-50%, -50%);
     }
 
     &[data-chair-position="top"]::before {
       top: -11px;
-      left: 9px;
+      left: 50%;
+      transform: translate(-50%, -50%);
     }
 
     &[data-chair-position="bottom"]::before {
-      left: 9px;
       bottom: -11px;
+      left: 50%;
+      transform: translate(-50%, 50%);
     }
 
     &[data-chair-position="left"]::before {
-      top: 9px;
       left: -11px;
+      top: 50%;
+      transform: translate(-50%, -50%);
     }
 
     &[data-chair-position="right"]::before {
-      top: 9px;
       right: -11px;
+      top: 50%;
+      transform: translate(50%, -50%);
     }
   }
 

--- a/assets/js/admin/seatmap.js
+++ b/assets/js/admin/seatmap.js
@@ -52,6 +52,7 @@ document.addEventListener('DOMContentLoaded', function () {
     })
 
     "use strict";
+    let xhr;
     let AjaxModal = function (remoteTarget) {
         this.remoteTarget = remoteTarget;
         /*this.$modal.on(
@@ -82,9 +83,15 @@ document.addEventListener('DOMContentLoaded', function () {
         },
         _getRemoteContent() {
             return new Promise((resolve, reject) => {
+                xhr && xhr.readyState && console.log('xhr', xhr && xhr.readyState)
+                if(xhr && xhr.readyState != 4){
+                    xhr.abort();
+                }
+                xhr = new window.XMLHttpRequest(); // only HttpRequest instance has .abort() method
                 $.ajax({
                     method: 'GET',
                     url: this.remoteTarget,
+                    xhr: () => xhr
                 }).then((data, textStatus, jqXHR) => {
                     resolve(data);
                 }).catch((jqXHR) => {

--- a/assets/js/admin/seatmap.js
+++ b/assets/js/admin/seatmap.js
@@ -83,8 +83,7 @@ document.addEventListener('DOMContentLoaded', function () {
         },
         _getRemoteContent() {
             return new Promise((resolve, reject) => {
-                xhr && xhr.readyState && console.log('xhr', xhr && xhr.readyState)
-                if(xhr && xhr.readyState != 4){
+                if (xhr && xhr.readyState != 4){
                     xhr.abort();
                 }
                 xhr = new window.XMLHttpRequest(); // only HttpRequest instance has .abort() method

--- a/src/Controller/Admin/SeatmapController.php
+++ b/src/Controller/Admin/SeatmapController.php
@@ -12,6 +12,7 @@ use App\Idm\IdmRepository;
 use App\Repository\SeatRepository;
 use App\Service\GamerService;
 use App\Service\SeatmapService;
+use App\Service\SettingService;
 use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -31,15 +32,17 @@ class SeatmapController extends AbstractController
     private readonly EntityManagerInterface $em;
     private readonly GamerService $gamerService;
     private readonly SeatmapService $seatmapService;
+    private readonly SettingService $settingService;
     private readonly SeatRepository $seatRepository;
     private readonly SerializerInterface $serializer;
 
-    public function __construct(EntityManagerInterface $em, GamerService $gamerService, IdmManager $manager, SeatmapService $seatmapService, SeatRepository $seatRepository, SerializerInterface $serializer)
+    public function __construct(EntityManagerInterface $em, GamerService $gamerService, IdmManager $manager, SeatmapService $seatmapService, SettingService $settingService, SeatRepository $seatRepository, SerializerInterface $serializer)
     {
         $this->em = $em;
         $this->userRepo = $manager->getRepository(User::class);
         $this->gamerService = $gamerService;
         $this->seatmapService = $seatmapService;
+        $this->settingService = $settingService;
         $this->seatRepository = $seatRepository;
         $this->serializer = $serializer;
     }
@@ -150,6 +153,10 @@ class SeatmapController extends AbstractController
                 return $this->redirectToRoute('admin_seatmap');
             } else {
                 // Create multiple Seats
+                $seatSize = $this->settingService->get('lan.seatmap.styles.seat_size');
+                $seatMultiplier = $this->settingService->get('lan.seatmap.styles.seat_tablewidth_multiplier');
+                $seatSpacing = $this->settingService->get('lan.seatmap.styles.seat_multiple_seats_distance');
+                
                 $x = $seat->getPosX();
                 $y = $seat->getPosY();
                 $i = 1;
@@ -163,9 +170,9 @@ class SeatmapController extends AbstractController
                     $this->em->persist($newSeat);
 
                     if ($seat->getChairPosition() == 'top' || $seat->getChairPosition() == 'bottom') {
-                        $x += 29;
+                        $x += $seatSize * $seatMultiplier + $seatSpacing;
                     } else {
-                        $y += 29;
+                        $y += $seatSize * $seatMultiplier + $seatSpacing;
                     }
                     $seatNumber += 2;
                     ++$i;

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -28,7 +28,7 @@ class Content implements HistoryAwareEntity
     private ?string $description;
 
     #[ORM\Column(type: 'string', length: 255, unique: true, nullable: true)]
-    #[Assert\Regex('/^[a-z]*$/', message: 'Nur Kleinbuchstaben sind hier erlaubt.')]
+    #[Assert\Regex('/^[a-z-]*$/', message: 'Nur Kleinbuchstaben und Bindestriche sind hier erlaubt.')]
     private ?string $alias;
 
     public function __construct()

--- a/src/Service/SettingService.php
+++ b/src/Service/SettingService.php
@@ -151,7 +151,7 @@ class SettingService
         return $this->repo->findByKey($key) ?? new Setting($key);
     }
 
-    public function get(string $key, $default = '')
+    public function get(string $key, $default = null)
     {
         $key = strtolower($key);
         if (!static::validKey($key)) {
@@ -168,14 +168,10 @@ class SettingService
         }
 
         if (!isset($this->cache[$key])) {
-            // valid key, but not yet created, default defined in template
-            if ($default) {
-                return $default;
-            }
-            
-            // valid key, but not yet created, default value from settings
-            return self::getDefaultValue($key);
+            // valid key, but not yet created. return either template or service default value
+            return !is_null($default) ? $default : self::getDefaultValue($key);
         }
+
         if (self::getType($key) == self::TB_TYPE_FILE) {
             return $this->uploaderHelper->asset($this->cache[$key], 'file', Setting::class);
         } else {

--- a/src/Service/SettingService.php
+++ b/src/Service/SettingService.php
@@ -53,6 +53,11 @@ class SettingService
         'lan.seatmap.allow_booking_for_non_paid' => [self::TB_DESCRIPTION => 'Sitzplanbuchungen für nicht bezahlte Gamer erlauben', self::TB_TYPE => self::TB_TYPE_BOOL],
         'lan.seatmap.locked' => [self::TB_DESCRIPTION => 'Sitzplanbuchungen sperren (Kein Reservieren/Freigeben für User)', self::TB_TYPE => self::TB_TYPE_BOOL],
         'lan.seatmap.bg_image' => [self::TB_DESCRIPTION => 'Sitzplan Hintergrundbild', self::TB_TYPE => self::TB_TYPE_FILE],
+        
+        'lan.seatmap.styles.seat_size' => [self::TB_DESCRIPTION => 'Sitzplatz Größe (px)', self::TB_TYPE => self::TB_TYPE_STRING],
+        'lan.seatmap.styles.seat_tablewidth_multiplier' => [self::TB_DESCRIPTION => 'Sitzplatz Seitenverhältnis (1 für 1/1 quadratisch, 1.5 oder 2 für breitere Tischanzeige), 1 Standard', self::TB_TYPE => self::TB_TYPE_STRING],
+        'lan.seatmap.styles.seat_border_radius' => [self::TB_DESCRIPTION => 'Border Radios des Sitzes (px), 8 Standard', self::TB_TYPE => self::TB_TYPE_STRING],
+        'lan.seatmap.styles.seat_bullet_size' => [self::TB_DESCRIPTION => 'Sesselgröße im Sitzplan (px), 6 Standard', self::TB_TYPE => self::TB_TYPE_STRING],
 
         'lan.stats.show' => [self::TB_DESCRIPTION => 'Statistiken zur Anmeldung anzeigen', self::TB_TYPE => self::TB_TYPE_BOOL],
 

--- a/src/Service/SettingService.php
+++ b/src/Service/SettingService.php
@@ -13,6 +13,7 @@ class SettingService
 {
     private const TB_TYPE = 'type';
     private const TB_DESCRIPTION = 'description';
+    private const TB_DEFAULT_VALUE = 'default';
     final public const TB_TYPE_STRING = 'string';
     final public const TB_TYPE_HTML = 'html';
     final public const TB_TYPE_URL = 'url';
@@ -54,10 +55,11 @@ class SettingService
         'lan.seatmap.locked' => [self::TB_DESCRIPTION => 'Sitzplanbuchungen sperren (Kein Reservieren/Freigeben für User)', self::TB_TYPE => self::TB_TYPE_BOOL],
         'lan.seatmap.bg_image' => [self::TB_DESCRIPTION => 'Sitzplan Hintergrundbild', self::TB_TYPE => self::TB_TYPE_FILE],
         
-        'lan.seatmap.styles.seat_size' => [self::TB_DESCRIPTION => 'Sitzplatz Größe (px)', self::TB_TYPE => self::TB_TYPE_STRING],
-        'lan.seatmap.styles.seat_tablewidth_multiplier' => [self::TB_DESCRIPTION => 'Sitzplatz Seitenverhältnis (1 für 1/1 quadratisch, 1.5 oder 2 für breitere Tischanzeige), 1 Standard', self::TB_TYPE => self::TB_TYPE_STRING],
-        'lan.seatmap.styles.seat_border_radius' => [self::TB_DESCRIPTION => 'Border Radios des Sitzes (px), 8 Standard', self::TB_TYPE => self::TB_TYPE_STRING],
-        'lan.seatmap.styles.seat_bullet_size' => [self::TB_DESCRIPTION => 'Sesselgröße im Sitzplan (px), 6 Standard', self::TB_TYPE => self::TB_TYPE_STRING],
+        'lan.seatmap.styles.seat_size' => [self::TB_DESCRIPTION => 'Sitzplatz Höhe/Breite (px)', self::TB_TYPE => self::TB_TYPE_STRING, self::TB_DEFAULT_VALUE => 27],
+        'lan.seatmap.styles.seat_tablewidth_multiplier' => [self::TB_DESCRIPTION => 'Sitzplatz Seitenverhältnis (1 für 1/1 quadratisch, 1.5 oder 2 für breitere Sitzplätze)', self::TB_TYPE => self::TB_TYPE_STRING, self::TB_DEFAULT_VALUE => 1],
+        'lan.seatmap.styles.seat_border_radius' => [self::TB_DESCRIPTION => 'Border Radios des Sitzes (px)', self::TB_TYPE => self::TB_TYPE_STRING, self::TB_DEFAULT_VALUE => 8],
+        'lan.seatmap.styles.seat_bullet_size' => [self::TB_DESCRIPTION => 'Sesselgröße im Sitzplan (px)', self::TB_TYPE => self::TB_TYPE_STRING, self::TB_DEFAULT_VALUE => 6],
+        'lan.seatmap.styles.seat_multiple_seats_distance' => [self::TB_DESCRIPTION => 'Abstand der Sitzplätze (px)', self::TB_TYPE => self::TB_TYPE_STRING, self::TB_DEFAULT_VALUE => 2],
 
         'lan.stats.show' => [self::TB_DESCRIPTION => 'Statistiken zur Anmeldung anzeigen', self::TB_TYPE => self::TB_TYPE_BOOL],
 
@@ -124,6 +126,14 @@ class SettingService
         return self::validKey($key) ? self::TEXT_BLOCK_KEYS[$key][self::TB_DESCRIPTION] : '';
     }
 
+    public static function getDefaultValue(string $key): string
+    {
+        if (isset(self::TEXT_BLOCK_KEYS[$key][self::TB_DEFAULT_VALUE]) && !empty(self::TEXT_BLOCK_KEYS[$key][self::TB_DEFAULT_VALUE])) {
+            return self::TEXT_BLOCK_KEYS[$key][self::TB_DEFAULT_VALUE];
+        }
+        return '';
+    }
+
     public function isSet(string $key): bool
     {
         return self::validKey($key) && !empty($this->get($key));
@@ -158,8 +168,13 @@ class SettingService
         }
 
         if (!isset($this->cache[$key])) {
-            // valid key, but not yet crated
-            return $default;
+            // valid key, but not yet created, default defined in template
+            if ($default) {
+                return $default;
+            }
+            
+            // valid key, but not yet created, default value from settings
+            return self::getDefaultValue($key);
         }
         if (self::getType($key) == self::TB_TYPE_FILE) {
             return $this->uploaderHelper->asset($this->cache[$key], 'file', Setting::class);

--- a/templates/admin/seatmap/index.html.twig
+++ b/templates/admin/seatmap/index.html.twig
@@ -5,6 +5,12 @@
 {% block main %}
     <div class="row">
         <div class="col-12">
+            {% set seatmap_bg = settings.get('lan.seatmap.bg_image') %}
+            {% if seatmap_bg is empty %}
+            <div class="card-body">
+                Lade einen Grundriss hoch um den Sitzplan zu erstellen: <a href="/admin/setting/edit?key=lan.seatmap.bg_image">Zu den Einstellungen</a>
+            </div>
+            {% else %}
             <div class="card-body">
                 <a class="btn btn-primary" href="{{ path('admin_seatmap_export') }}" download>Sitzplan exportieren (.csv)</a>
             </div>
@@ -31,7 +37,6 @@
             <div class="d-flex justify-content-center mt-5">
                 <div class="card">
                     <div class="seatmap" data-position-url="{{ path('admin_seatmap_seat_pos') }}" data-create-url="{{ path('admin_seatmap_seat_create') }}">
-                        {% set seatmap_bg = settings.get('lan.seatmap.bg_image') %}
                         {% if seatmap_bg is not empty %}
                             <img class="seatmap-bg" src="{{ seatmap_bg }}" aria-hidden="true">
                         {% endif %}
@@ -64,6 +69,7 @@
                     </div>
                 </div>
             </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}
@@ -75,5 +81,21 @@
 
 {% block stylesheets %}
     {{ parent() }}
+    <style type="text/css">
+        :root {
+            {% if settings.get('lan.seatmap.styles.seat_size', false) %}
+            --seatmap-seat-size: {{ settings.get('lan.seatmap.styles.seat_size') }}px;
+            {% endif %}
+            {% if settings.get('lan.seatmap.styles.seat_tablewidth_multiplier', false) %}
+            --seatmap-seat-tableWidthMultiplier: {{ settings.get('lan.seatmap.styles.seat_tablewidth_multiplier') }};
+            {% endif %}
+            {% if settings.get('lan.seatmap.styles.seat_bullet_size', false) %}
+            --seatmap-seat-bullet-size: {{ settings.get('lan.seatmap.styles.seat_bullet_size') }}px;
+            {% endif %}
+            {% if settings.get('lan.seatmap.styles.seat_border_radius', 10) %}
+            --seatmap-seat-border-radius: {{ settings.get('lan.seatmap.styles.seat_border_radius', 10) }}px;
+            {% endif %}
+        }
+    </style>
     {{ encore_entry_link_tags('admin_seatmap') }}
 {% endblock %}

--- a/templates/admin/seatmap/index.html.twig
+++ b/templates/admin/seatmap/index.html.twig
@@ -8,7 +8,7 @@
             {% set seatmap_bg = settings.get('lan.seatmap.bg_image') %}
             {% if seatmap_bg is empty %}
             <div class="card-body">
-                Lade einen Grundriss hoch um den Sitzplan zu erstellen: <a href="/admin/setting/edit?key=lan.seatmap.bg_image">Zu den Einstellungen</a>
+                Lade einen Grundriss hoch um den Sitzplan zu erstellen: <a href="{{ path('admin_setting_edit', {'key': 'lan.seatmap.bg_image'}) }}">Zu den Einstellungen</a>
             </div>
             {% else %}
             <div class="card-body">
@@ -83,18 +83,10 @@
     {{ parent() }}
     <style type="text/css">
         :root {
-            {% if settings.get('lan.seatmap.styles.seat_size', false) %}
             --seatmap-seat-size: {{ settings.get('lan.seatmap.styles.seat_size') }}px;
-            {% endif %}
-            {% if settings.get('lan.seatmap.styles.seat_tablewidth_multiplier', false) %}
             --seatmap-seat-tableWidthMultiplier: {{ settings.get('lan.seatmap.styles.seat_tablewidth_multiplier') }};
-            {% endif %}
-            {% if settings.get('lan.seatmap.styles.seat_bullet_size', false) %}
             --seatmap-seat-bullet-size: {{ settings.get('lan.seatmap.styles.seat_bullet_size') }}px;
-            {% endif %}
-            {% if settings.get('lan.seatmap.styles.seat_border_radius', 10) %}
             --seatmap-seat-border-radius: {{ settings.get('lan.seatmap.styles.seat_border_radius', 10) }}px;
-            {% endif %}
         }
     </style>
     {{ encore_entry_link_tags('admin_seatmap') }}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -6,6 +6,22 @@
         <meta http-equiv="cache-control" content="no-cache"/>
         {% block favicon %}<link rel="shortcut icon" href="{{ asset('favicon.ico') }}" />{% endblock %}
         <title>{% block title %}{{ settings.get('site.title') }}{% endblock %}</title>
+        <style type="text/css">
+            :root {
+                {% if settings.get('lan.seatmap.styles.seat_size', false) %}
+                --seatmap-seat-size: {{ settings.get('lan.seatmap.styles.seat_size') }}px;
+                {% endif %}
+                {% if settings.get('lan.seatmap.styles.seat_tablewidth_multiplier', false) %}
+                --seatmap-seat-tableWidthMultiplier: {{ settings.get('lan.seatmap.styles.seat_tablewidth_multiplier') }};
+                {% endif %}
+                {% if settings.get('lan.seatmap.styles.seat_bullet_size', false) %}
+                --seatmap-seat-bullet-size: {{ settings.get('lan.seatmap.styles.seat_bullet_size') }}px;
+                {% endif %}
+                {% if settings.get('lan.seatmap.styles.seat_border_radius', false) %}
+                --seatmap-seat-border-radius: {{ settings.get('lan.seatmap.styles.seat_border_radius') }}px;
+                {% endif %}
+            }
+        </style>
         {% block stylesheets %}
             {{ encore_entry_link_tags('app') }}
         {% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -6,22 +6,6 @@
         <meta http-equiv="cache-control" content="no-cache"/>
         {% block favicon %}<link rel="shortcut icon" href="{{ asset('favicon.ico') }}" />{% endblock %}
         <title>{% block title %}{{ settings.get('site.title') }}{% endblock %}</title>
-        <style type="text/css">
-            :root {
-                {% if settings.get('lan.seatmap.styles.seat_size', false) %}
-                --seatmap-seat-size: {{ settings.get('lan.seatmap.styles.seat_size') }}px;
-                {% endif %}
-                {% if settings.get('lan.seatmap.styles.seat_tablewidth_multiplier', false) %}
-                --seatmap-seat-tableWidthMultiplier: {{ settings.get('lan.seatmap.styles.seat_tablewidth_multiplier') }};
-                {% endif %}
-                {% if settings.get('lan.seatmap.styles.seat_bullet_size', false) %}
-                --seatmap-seat-bullet-size: {{ settings.get('lan.seatmap.styles.seat_bullet_size') }}px;
-                {% endif %}
-                {% if settings.get('lan.seatmap.styles.seat_border_radius', false) %}
-                --seatmap-seat-border-radius: {{ settings.get('lan.seatmap.styles.seat_border_radius') }}px;
-                {% endif %}
-            }
-        </style>
         {% block stylesheets %}
             {{ encore_entry_link_tags('app') }}
         {% endblock %}

--- a/templates/site/seatmap/index.html.twig
+++ b/templates/site/seatmap/index.html.twig
@@ -68,18 +68,10 @@
     {{ parent() }}
     <style type="text/css">
         :root {
-            {% if settings.get('lan.seatmap.styles.seat_size', false) %}
             --seatmap-seat-size: {{ settings.get('lan.seatmap.styles.seat_size') }}px;
-            {% endif %}
-            {% if settings.get('lan.seatmap.styles.seat_tablewidth_multiplier', false) %}
             --seatmap-seat-tableWidthMultiplier: {{ settings.get('lan.seatmap.styles.seat_tablewidth_multiplier') }};
-            {% endif %}
-            {% if settings.get('lan.seatmap.styles.seat_bullet_size', false) %}
             --seatmap-seat-bullet-size: {{ settings.get('lan.seatmap.styles.seat_bullet_size') }}px;
-            {% endif %}
-            {% if settings.get('lan.seatmap.styles.seat_border_radius', false) %}
-            --seatmap-seat-border-radius: {{ settings.get('lan.seatmap.styles.seat_border_radius') }}px;
-            {% endif %}
+            --seatmap-seat-border-radius: {{ settings.get('lan.seatmap.styles.seat_border_radius', 10) }}px;
         }
     </style>
     {{ encore_entry_link_tags('seatmap') }}

--- a/templates/site/seatmap/index.html.twig
+++ b/templates/site/seatmap/index.html.twig
@@ -66,5 +66,21 @@
 
 {% block stylesheets %}
     {{ parent() }}
+    <style type="text/css">
+        :root {
+            {% if settings.get('lan.seatmap.styles.seat_size', false) %}
+            --seatmap-seat-size: {{ settings.get('lan.seatmap.styles.seat_size') }}px;
+            {% endif %}
+            {% if settings.get('lan.seatmap.styles.seat_tablewidth_multiplier', false) %}
+            --seatmap-seat-tableWidthMultiplier: {{ settings.get('lan.seatmap.styles.seat_tablewidth_multiplier') }};
+            {% endif %}
+            {% if settings.get('lan.seatmap.styles.seat_bullet_size', false) %}
+            --seatmap-seat-bullet-size: {{ settings.get('lan.seatmap.styles.seat_bullet_size') }}px;
+            {% endif %}
+            {% if settings.get('lan.seatmap.styles.seat_border_radius', false) %}
+            --seatmap-seat-border-radius: {{ settings.get('lan.seatmap.styles.seat_border_radius') }}px;
+            {% endif %}
+        }
+    </style>
     {{ encore_entry_link_tags('seatmap') }}
 {% endblock %}


### PR DESCRIPTION
- style settings for table size, table aspect ratio, border radius and seat size, seating distance
- proper multiple-seat-creation calculation respecting width + distance
- kill duplicate seat-creation modal xhrs (eg on double right-click or slow connection)
- sneak in: for /content/ routes, [allow dashes in slugs](https://github.com/KRRUg/KLMS/pull/116/commits/8394d605428143bf1aeb1329de3335b3c6caf9ab#diff-975333add6f5949b81a576e69b655b18df4b2aef7bdbf95c7b308223a276b3d6R31) 

Example for non-standard table size:
<img width="500" alt="Bildschirmfoto 2023-12-07 um 23 27 55" src="https://github.com/KRRUg/KLMS/assets/1720843/6d133492-4d0a-48bb-829d-d6048ee61c42">
