### PR TITLE
feat: add battle.net account to user profile

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -93,6 +93,10 @@ class User
     #[Groups(['read', 'write'])]
     private ?string $steamAccount = null;
 
+    #[Assert\Length(max: 250, maxMessage: 'The battle.net account cannot be longer than {{ limit }} characters')]
+    #[Groups(['read', 'write'])]
+    private ?string $battlenetAccount = null;
+
     #[Groups(['read'])]
     private ?DateTimeInterface $registeredAt = null;
 
@@ -347,6 +351,18 @@ class User
     public function setSteamAccount(?string $steamAccount): self
     {
         $this->steamAccount = $steamAccount;
+
+        return $this;
+    }
+
+    public function getBattlenetAccount(): ?string
+    {
+        return $this->battlenetAccount;
+    }
+
+    public function setBattlenetAccount(?string $battlenetAccount): self
+    {
+        $this->battlenetAccount = $battlenetAccount;
 
         return $this;
     }

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -81,6 +81,10 @@ class UserType extends AbstractType
                 'label' => 'Steam Account',
                 'required' => false,
             ])
+            ->add('battlenetAccount', TextType::class, [
+                'label' => 'Battle.net Account',
+                'required' => false,
+            ])
             ->add('hardware', TextareaType::class, [
                 'required' => false,
             ])

--- a/templates/admin/user/edit.html.twig
+++ b/templates/admin/user/edit.html.twig
@@ -76,6 +76,7 @@
                     <hr>
                     {{ form_row(form.phone, {'input_group_prepend' : '<i class="fas fa-mobile-alt fa-fw"></i>'}) }}
                     {{ form_row(form.steamAccount, {'input_group_prepend' : '<i class="fab fa-steam fa-fw"></i>'}) }}
+                    {{ form_row(form.battlenetAccount, {'input_group_prepend' : '<i class="fab fa-battle-net fa-fw"></i>'}) }}
                     {{ form_row(form.website, {'input_group_prepend' : '<i class="fas fa-globe fa-fw"></i>'}) }}
                     {{ form_row(form.hardware, {'input_group_prepend' : '<i class="fas fa-desktop fa-fw"></i>'}) }}
                     {{ form_row(form.statements, {'input_group_prepend' : '<i class="far fa-comment-dots fa-fw"></i>'}) }}

--- a/templates/admin/user/show.html.twig
+++ b/templates/admin/user/show.html.twig
@@ -107,6 +107,9 @@
                             <i class="fab fa-steam fa-fw mr-3" title="Steam Account"></i>{{ user.steamaccount }}
                         </li>
                         <li class="list-group-item">
+                            <i class="fab fa-battle-net fa-fw mr-3" title="Battle.net Account"></i>{{ user.battlenetaccount }}
+                        </li>
+                        <li class="list-group-item">
                             <i class="fas fa-desktop fa-fw mr-3" title="Hardware"></i>{{ user.hardware }}
                         </li>
                         <li class="list-group-item">

--- a/templates/site/user/edit.html.twig
+++ b/templates/site/user/edit.html.twig
@@ -51,6 +51,7 @@
                 {{ form_row(form.statements, {'input_group_prepend' : '<i class="far fa-comment-dots"></i>'}) }}
                 {{ form_row(form.phone, {'input_group_prepend' : '<i class="fas fa-mobile-alt"></i>'}) }}
                 {{ form_row(form.steamAccount, {'input_group_prepend' : '<i class="fab fa-steam"></i>'}) }}
+                {{ form_row(form.battlenetAccount, {'input_group_prepend' : '<i class="fab fa-battle-net"></i>'}) }}
                 {{ form_row(form.website, {'input_group_prepend' : '<i class="fas fa-globe"></i>'}) }}
                 {{ form_row(form.hardware, {'input_group_prepend' : '<i class="fas fa-desktop"></i>'}) }}
                 <hr>

--- a/templates/site/user/show.html.twig
+++ b/templates/site/user/show.html.twig
@@ -94,6 +94,11 @@
                             <i class="fab fa-steam fa-fw mr-3" title="Steam Account"></i>{{ user.steamaccount }}
                         </li>
                     {% endif %}
+                    {% if user.battlenetaccount | trim %}
+                        <li class="list-group-item">
+                            <i class="fab fa-battle-net fa-fw mr-3" title="Battle.net Account"></i>{{ user.battlenetaccount }}
+                        </li>
+                    {% endif %}
                     {% if user.website | trim %}
                         <li class="list-group-item">
                             <i class="fas fa-globe fa-fw mr-3" title="Webseite"></i><a href="{{ user.website }}" target="_blank">{{ user.website }}</a>


### PR DESCRIPTION
Adds Battle.net account to the user profile below steam account. 

profile modal:
<img width="356" alt="Bildschirmfoto 2023-12-20 um 15 32 17" src="https://github.com/KRRUg/KLMS/assets/1720843/439bc568-6cf3-4dae-a746-7b8b3fa48043">

profile edit:
<img width="457" alt="Bildschirmfoto 2023-12-20 um 15 31 31" src="https://github.com/KRRUg/KLMS/assets/1720843/9c81d9b9-b45c-411f-b556-493f6753f050">


Part 2/2, see also PR [IDM#18](https://github.com/KRRUg/IDM/pull/18)